### PR TITLE
Added config option to filter logging output

### DIFF
--- a/bin/omega-server
+++ b/bin/omega-server
@@ -149,7 +149,19 @@ accessible administrative methods") do
     RJR::Logger.add_filter proc { |m| !(m =~ /.*get_entit.*/ ) }
     RJR::Logger.add_filter proc { |m| !(m =~ /.*moving location.*/ ) }
     #RJR::Logger.highlight proc { |m| m =~ /.*text to hightlight.*/}
-    # TODO allow user to add / customize filters and highlights via config file (and command line flags?)
+  end
+  
+  # get logging filters from config
+  unless config[:log_filters].nil?
+    config[:log_filters].each { |string| 
+      begin
+        regexp = Regexp.new string
+        RJR::Logger.add_filter proc { |m| !(m =~ regexp) }        
+      rescue RegexpError => e
+        puts "Invalid regexp set as filter (#{e.to_s}) - Exiting" # should we probably keep running?
+        exit
+      end
+    }
   end
 
   # setup the omega systems

--- a/omega.yml
+++ b/omega.yml
@@ -70,6 +70,9 @@ recaptcha_enabled: true
 recaptcha_pub_key:  'CHANGE_ME' # FIXME: not currently used, need to set in javascript client
 recaptcha_priv_key: 'CHANGE_ME'
 
+# logging filters - specify regexes to exclude from the omega logs
+#log_filters: ['regexp1', 'regexp2']
+
 # TODO config options for
 # rjr: node threads, node timeout
 # motel: step_delay


### PR DESCRIPTION
I added the possibility to get filters from the configuration. The reason I decided to exit the execution in case of error is that a non-fatal warning would probably get lost under a lot of logging messages.
