### PR TITLE
Modifed spec files so that should_not raise_error does not take any argument

### DIFF
--- a/spec/cosmos/rjr/create_spec.rb
+++ b/spec/cosmos/rjr/create_spec.rb
@@ -44,7 +44,7 @@ module Cosmos::RJR
         new_entity = build(:galaxy)
         lambda {
           @s.create_entity(new_entity)
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       context "non-entity specified" do

--- a/spec/cosmos/rjr/get_spec.rb
+++ b/spec/cosmos/rjr/get_spec.rb
@@ -75,7 +75,7 @@ module Cosmos::RJR
           g = create(:galaxy)
           lambda {
             @s.get_entities 'with_id', g.id
-          }.should_not raise_error(PermissionError)
+          }.should_not raise_error()
         end
 
         it "returns corresponding entity" do

--- a/spec/manufactured/entity_spec.rb
+++ b/spec/manufactured/entity_spec.rb
@@ -172,7 +172,7 @@ describe HasCargo do
 
         lambda{
           @e.remove_resource r
-        }.should_not raise_error(RuntimeError)
+        }.should_not raise_error()
       end
     end
 

--- a/spec/manufactured/rjr/attack_spec.rb
+++ b/spec/manufactured/rjr/attack_spec.rb
@@ -83,7 +83,7 @@ module Manufactured::RJR
       it "does not raise PermissionError" do
         lambda {
           @s.attack_entity @at.id, @df.id
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       it "creates new attack command" do

--- a/spec/manufactured/rjr/create_spec.rb
+++ b/spec/manufactured/rjr/create_spec.rb
@@ -49,7 +49,7 @@ module Manufactured::RJR
         s = build_ship
         lambda {
           @s.create_entity(s)
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       context "invalid entity type specified" do
@@ -247,7 +247,7 @@ module Manufactured::RJR
       it "does not raise PermissionError" do
         lambda {
           @s.construct_entity @st.id, @construct
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       it "filters all properties but id, type, and entity_type" do

--- a/spec/manufactured/rjr/dock_spec.rb
+++ b/spec/manufactured/rjr/dock_spec.rb
@@ -67,7 +67,7 @@ module Manufactured::RJR
       it "does not raise PermissionError" do
         lambda {
           @s.dock @sh.id, @st.id
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       it "updates ship location" do

--- a/spec/manufactured/rjr/loot_spec.rb
+++ b/spec/manufactured/rjr/loot_spec.rb
@@ -77,7 +77,7 @@ module Manufactured::RJR
       it "does not raise PermissionError" do
         lambda {
           @s.collect_loot @sh.id, @lt.id
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       it "updates ship location" do

--- a/spec/manufactured/rjr/mining_spec.rb
+++ b/spec/manufactured/rjr/mining_spec.rb
@@ -54,7 +54,7 @@ module Manufactured::RJR
       it "does not raise PermissionError" do
         lambda{
           @s.start_mining @miner.id, @rs.id
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       it "creates new mining command" do

--- a/spec/manufactured/rjr/movement_spec.rb
+++ b/spec/manufactured/rjr/movement_spec.rb
@@ -298,7 +298,7 @@ module Manufactured::RJR
       it "does not raise PermissionError" do
         lambda {
           @s.move_entity @sh.id, @l
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       context "invalid location" do
@@ -446,7 +446,7 @@ module Manufactured::RJR
       it "does not raise PermissionError" do
         lambda {
           @s.follow_entity @sh.id, @sh1.id, 10
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       it "updates entity & target location & system" do
@@ -551,7 +551,7 @@ module Manufactured::RJR
       it "does not raise PermissionError" do
         lambda {
           @s.stop_entity @sh.id
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       it "updates entity location" do

--- a/spec/manufactured/rjr/resources_spec.rb
+++ b/spec/manufactured/rjr/resources_spec.rb
@@ -43,7 +43,7 @@ module Manufactured::RJR
       it "does not raise PermissionError" do
         lambda {
           @s.add_resource 'whatever', @rs
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       context "invalid entity id" do
@@ -160,7 +160,7 @@ module Manufactured::RJR
       it "does not raise PermissionError" do
         lambda {
           @s.transfer_resource @src.id, @dst.id, @rs
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       it "updates src/dst locations from motel" do

--- a/spec/missions/rjr/create_spec.rb
+++ b/spec/missions/rjr/create_spec.rb
@@ -38,7 +38,7 @@ module Missions::RJR
         new_event = build(:event)
         lambda {
           @s.create_event(new_event)
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       context "non-event specified" do
@@ -98,7 +98,7 @@ module Missions::RJR
         new_mission = build(:mission)
         lambda {
           @s.create_mission(new_mission)
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       context "non-mission specified" do

--- a/spec/motel/rjr/create_spec.rb
+++ b/spec/motel/rjr/create_spec.rb
@@ -38,7 +38,7 @@ module Motel::RJR
         new_location = build(:location)
         lambda {
           @s.create_location(new_location)
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       context "non-location specified" do

--- a/spec/motel/rjr/delete_spec.rb
+++ b/spec/motel/rjr/delete_spec.rb
@@ -38,7 +38,7 @@ module Motel::RJR
         loc = create(:location)
         lambda {
           @s.delete_location(loc.id)
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
 
       context "invalid location_id specified" do

--- a/spec/motel/rjr/get_spec.rb
+++ b/spec/motel/rjr/get_spec.rb
@@ -54,7 +54,7 @@ module Motel::RJR
             l = create(:location, :restrict_view => false)
             lambda {
               @s.get_location 'with_id', l.id
-            }.should_not raise_error(PermissionError)
+            }.should_not raise_error()
           end
 
           it "returns corresponding location" do

--- a/spec/users/rjr/create_spec.rb
+++ b/spec/users/rjr/create_spec.rb
@@ -41,7 +41,7 @@ module Users::RJR
           new_user = build(:user)
           lambda {
             @s.create_user(new_user)
-          }.should_not raise_error(PermissionError)
+          }.should_not raise_error()
         end
       end
     end
@@ -140,7 +140,7 @@ module Users::RJR
           new_role = build(:role)
           lambda {
             @s.create_role(new_role)
-          }.should_not raise_error(PermissionError)
+          }.should_not raise_error()
         end
       end
     end

--- a/spec/users/rjr/permissions_spec.rb
+++ b/spec/users/rjr/permissions_spec.rb
@@ -43,7 +43,7 @@ module Users::RJR
           role = create(:role)
           lambda {
             @s.add_role(user.id, role.id)
-          }.should_not raise_error(PermissionError)
+          }.should_not raise_error()
         end
       end
     end
@@ -105,7 +105,7 @@ module Users::RJR
       it "does not raise permission error" do
         lambda {
           @s.remove_role(@user.id, @role.id)
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
     end
 
@@ -128,7 +128,7 @@ module Users::RJR
           add_privilege(@login_role, 'modify', 'roles')
           lambda {
             @s.remove_role(@user.id, @role.id)
-          }.should_not raise_error(PermissionError)
+          }.should_not raise_error()
         end
       end
     end
@@ -201,7 +201,7 @@ module Users::RJR
           role = create(:role)
           lambda {
             @s.add_privilege(role.id, 'view')
-          }.should_not raise_error(PermissionError)
+          }.should_not raise_error()
         end
       end
     end
@@ -258,7 +258,7 @@ module Users::RJR
       it "does not raise permission error" do
         lambda {
           @s.remove_privilege(@role.id, 'view')
-        }.should_not raise_error(PermissionError)
+        }.should_not raise_error()
       end
     end
 
@@ -281,7 +281,7 @@ module Users::RJR
           add_privilege(@login_role, 'modify', 'roles')
           lambda {
             @s.remove_privilege(@role.id, 'view')
-          }.should_not raise_error(PermissionError)
+          }.should_not raise_error()
         end
       end
     end


### PR DESCRIPTION
When I tried running the testsuit with rspec I ran into this deprecation issue. Running rspec 2.14.7 BTW.

You can see a nice discussion about raise_error(ErrorType) here: https://github.com/rspec/rspec-expectations/issues/231
